### PR TITLE
Added exception for corrupt marker data

### DIFF
--- a/ssdv.c
+++ b/ssdv.c
@@ -721,7 +721,7 @@ static char ssdv_have_marker(ssdv_t *s)
 static char ssdv_have_marker_data(ssdv_t *s)
 {
 	uint8_t *d = s->marker_data;
-	size_t l = s->marker_len;
+	ssize_t l = s->marker_len;
 	int i;
 	
 	switch(s->marker)
@@ -879,6 +879,11 @@ static char ssdv_have_marker_data(ssdv_t *s)
 				j += d[i];
 			
 			l -= j;
+			if (l < 0)
+			{
+				fprintf(stderr, "The image has an invalid marker length\n");
+				return(SSDV_ERROR);
+			}
 			d += j;
 		}
 		break;
@@ -895,6 +900,11 @@ static char ssdv_have_marker_data(ssdv_t *s)
 			
 			/* Skip to the next one, if present */
 			l -= 65;
+			if (l < 0)
+			{
+				fprintf(stderr, "The image has an invalid marker length\n");
+				return(SSDV_ERROR);
+			}
 			d += 65;
 		}
 		break;


### PR DESCRIPTION
I had a faulty camera which sent me fauly JPEG data, which I sent into the SSDV algorithm.

`ssdv_have_marker_data` uses a variable `l` which is unsigned. When the algorithm comes to the `J_DQT` case, it loops until there is no marker data left (`l` = 0) and `l` is decremented by 64. In my case `l` wasn't a multiple of 64 and `l` underflowed.

E.g. 45 decremented by 64 is -19 but since it's an size_t (uint32_t on my target) it underflows to 4294967276. It continues to read from out-of-boundary addresses which lead to a segmentation fault (or hard fault on my STM32).